### PR TITLE
Test enhancement/Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: dependencies=highest
 before_script:
   - composer self-update
+  - mkdir -p build/log
   - if [ -z "$dependencies" ]; then composer install; fi;
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
   - if [ "$dependencies" = "highest" ]; then composer update -n; fi;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"consistence/coding-standard": "~0.13.0",
 		"jakub-onderka/php-parallel-lint": "^0.9",
 		"phpstan/phpstan": "^0.9",
-		"satooshi/php-coveralls": "dev-master",
+		"satooshi/php-coveralls": "^2.0",
 		"slevomat/coding-standard": "^2.0"
 	},
 	"autoload": {

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -13,9 +13,6 @@
 		<log
 			type="coverage-html"
 			target="../build/log/html"
-			charset="UTF-8"
-			lowUpperBound="0.0000000000001"
-			highLowerBound="99.999999999999"
 		/>
 		<log type="coverage-clover" target="../build/log/clover.xml"/>
 		<log
@@ -25,6 +22,11 @@
 			showOnlySummary="true"
 		/>
 	</logging>
+	<testsuites>
+        <testsuite name="Mocktainer Test Suite">
+            <directory>./Mocktainer</directory>
+        </testsuite>
+    </testsuites>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">../src</directory>


### PR DESCRIPTION
# Changed log
- To fix the Travis CI build, Adding the ```mkdir -p build/log``` to avoid the ```RuntimeException``` when executing the PHPUnit generating the code clover job.
- Add the test suite in ```phpunit.xml``` setting file.
- Remove the ```bootstrap``` file because the ```declare(strict_types = 1);``` has been already added in all related test class files. And it can add the bootstrap attribute: ```../vendor/autoload.php``` directly in ```phpunit.xml``` file.
- Remove some invalid attribute settings in ```phpunit.xml``` file.